### PR TITLE
Use updateErrors so fields are touched and server errors visible

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -100,7 +100,7 @@ export function useForm(args: IUseFormArgs = {}) {
         await onSubmit(values)
       }
       catch (e) {
-        setErrors(normalizeServerErrors(e))
+        updateErrors(normalizeServerErrors(e))
         throw e
       }
       finally {

--- a/src/useFormErrors.ts
+++ b/src/useFormErrors.ts
@@ -74,6 +74,13 @@ export function useFormErrors(args: IUseFormErrorsArgs) {
 
   function updateTouched(changedTouched) {
     setTouched({...ctx.touched, ...replaceValues(changedTouched, true)})
+    const untouchedExternalErrors = {...ctx.externalErrors}
+    Object.entries(changedTouched).forEach(([key, touched]) => {
+      if (touched) {
+        delete untouchedExternalErrors[key]
+      }
+    })
+    setExternalErrors(untouchedExternalErrors)
   }
 
   const handleBlurProxy = useProxy(


### PR DESCRIPTION
Errors thrown during submit currently aren't visible as the fields are not "touched"
If we use `updateErrors` instead of `setErrors`, these fields will be "touched" and the errors accessible through the proxy.